### PR TITLE
Implement Provider.list_zones for dynamic zone config support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
-## v0.0.2 - 2022-??-?? - Support the root
+## v0.0.2 - 202?-??-?? - Support the root and list the zones
 
 * Enable SUPPORTS_ROOT_NS for management of root NS records. Requires
   octodns>=0.9.16.
+* Support for Provider.list_zones to enable dynamic zone config when operating
+  as a source
 
 ## v0.0.1 - 2022-01-05 - Moving
 

--- a/octodns_digitalocean/__init__.py
+++ b/octodns_digitalocean/__init__.py
@@ -52,6 +52,25 @@ class DigitalOceanClient(object):
         resp.raise_for_status()
         return resp
 
+    def domains(self):
+        path = '/domains'
+        ret = []
+
+        page = 1
+        while True:
+            data = self._request('GET', path, {'page': page}).json()
+
+            ret += data['domains']
+            links = data['links']
+
+            try:
+                links['pages']['last']
+                page += 1
+            except KeyError:
+                break
+
+        return ret
+
     def domain(self, name):
         path = f'/domains/{name}'
         return self._request('GET', path).json()
@@ -201,6 +220,11 @@ class DigitalOceanProvider(BaseProvider):
                 return []
 
         return self._zone_records[zone.name]
+
+    def list_zones(self):
+        self.log.debug('list_zones:')
+        domains = [f'{d["name"]}.' for d in self._client.domains()]
+        return sorted(domains)
 
     def populate(self, zone, target=False, lenient=False):
         self.log.debug(

--- a/tests/fixtures/digitalocean-domains-page-1.json
+++ b/tests/fixtures/digitalocean-domains-page-1.json
@@ -1,0 +1,17 @@
+{
+  "domains": [{
+    "name": "unit.tests",
+    "ttl": 1800,
+    "zone_file": "..."
+  }, {
+    "name": "sub.unit.tests",
+    "ttl": 1800,
+    "zone_file": "..."
+  }],
+  "links": {
+    "pages": {
+      "last": "https://api.digitalocean.com/v2/domains?page=2",
+      "next": "https://api.digitalocean.com/v2/domains?page=2"
+    }
+  }
+}

--- a/tests/fixtures/digitalocean-domains-page-2.json
+++ b/tests/fixtures/digitalocean-domains-page-2.json
@@ -1,0 +1,17 @@
+{
+  "domains": [{
+    "name": "other.com",
+    "ttl": 1800,
+    "zone_file": "..."
+  }, {
+    "name": "something.farm",
+    "ttl": 3600,
+    "zone_file": "..."
+  }],
+  "links": {
+    "pages": {
+      "first": "https://api.digitalocean.com/v2/domains?page=1",
+      "prev": "https://api.digitalocean.com/v2/domains?page=1"
+    }
+  }
+}

--- a/tests/test_octodns_provider_digitalocean.py
+++ b/tests/test_octodns_provider_digitalocean.py
@@ -352,3 +352,23 @@ class TestDigitalOceanProvider(TestCase):
             ],
             any_order=True,
         )
+
+    def test_list_zones(self):
+        provider = DigitalOceanProvider('test', 'token')
+
+        with requests_mock() as mock:
+            base = 'https://api.digitalocean.com/v2/domains?page='
+            with open('tests/fixtures/digitalocean-domains-page-1.json') as fh:
+                mock.get(f'{base}1', text=fh.read())
+            with open('tests/fixtures/digitalocean-domains-page-2.json') as fh:
+                mock.get(f'{base}2', text=fh.read())
+
+            self.assertEqual(
+                [
+                    'other.com.',
+                    'something.farm.',
+                    'sub.unit.tests.',
+                    'unit.tests.',
+                ],
+                provider.list_zones(),
+            )


### PR DESCRIPTION
Per documentation https://docs.digitalocean.com/reference/api/api-reference/#tag/Domains, i don't have access currently to test it myself.

/cc https://github.com/octodns/octodns/pull/1026 for base functionality that will utilize this
/cc https://github.com/octodns/octodns/issues/1025 for tracking the work
/cc @octodns/review any of you have access to DigitalOcean to try running this against the actual service