### PR TITLE
Version 1.0.0 version bump & changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v1.0.0 - 2024-??-?? - Support the root and list the zones
+# v1.0.0 - 2025-05-03 - Support the root and list the zones
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x
 * Enable SUPPORTS_ROOT_NS for management of root NS records.

--- a/octodns_digitalocean/__init__.py
+++ b/octodns_digitalocean/__init__.py
@@ -13,7 +13,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '0.0.2'
+__version__ = __VERSION__ = '1.0.0'
 
 
 class DigitalOceanClientException(ProviderException):


### PR DESCRIPTION
# v1.0.0 - 2025-05-03 - Support the root and list the zones

* Address pending octoDNS 2.x deprecations, require minimum of 1.5.x
* Enable SUPPORTS_ROOT_NS for management of root NS records.
* Support for Provider.list_zones to enable dynamic zone config when operating
  as a source