### PR TITLE
Version 1.0.1 bump & changelog update

### DIFF
--- a/.changelog/0244311beb824f53869472cbc8933f42.md
+++ b/.changelog/0244311beb824f53869472cbc8933f42.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
+++ b/.changelog/05f3b5dc965240e7a07f71522e390fd9.md
@@ -1,4 +1,0 @@
----
-type: patch
----
-Use new [changelet](https://github.com/octodns/changelet) tooling

--- a/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
+++ b/.changelog/0c766cb99c8a419aa8af6396b7ee56aa.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Run changelog check during pre-commit

--- a/.changelog/12a659bdb32b4d8090c5c6f7ab142672.md
+++ b/.changelog/12a659bdb32b4d8090c5c6f7ab142672.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/2e3708cb25e74dfb94a3f0126f5f801d.md
+++ b/.changelog/2e3708cb25e74dfb94a3f0126f5f801d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Pull in the latest template changes

--- a/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
+++ b/.changelog/41bc3f8da3c84ca9a734d0be96c589c5.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update scripts to use common.sh

--- a/.changelog/4b1d0ae9cb5542cba8d6a4e4d02236ef.md
+++ b/.changelog/4b1d0ae9cb5542cba8d6a4e4d02236ef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/65e7b7c59da14a8d928446ae0b965ad3.md
+++ b/.changelog/65e7b7c59da14a8d928446ae0b965ad3.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements*.txt

--- a/.changelog/6a4e3dde61f94ca58119c62f14a31780.md
+++ b/.changelog/6a4e3dde61f94ca58119c62f14a31780.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements.txt

--- a/.changelog/7f722301e34140f7bbf0b4126709342d.md
+++ b/.changelog/7f722301e34140f7bbf0b4126709342d.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Add JSON coverage report format

--- a/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
+++ b/.changelog/8d5ac9f8740a4cdd9dde916a17e8ffef.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Switch to proviso for requirements.txt management

--- a/.changelog/a287e2b342974af1a1f7d43ebf5105cd.md
+++ b/.changelog/a287e2b342974af1a1f7d43ebf5105cd.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Update requirements

--- a/.changelog/ae3762a649b44418b4295fcfa219f5be.md
+++ b/.changelog/ae3762a649b44418b4295fcfa219f5be.md
@@ -1,4 +1,0 @@
----
-type: none
----
-Use script/common.sh in script/update-requirements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.1 - 2026-04-03
+
+Patch:
+* Use new [changelet](https://github.com/octodns/changelet) tooling - [#44](https://github.com/octodns/octodns-digitalocean/pull/44)
+
 # v1.0.0 - 2025-05-03 - Support the root and list the zones
 
 * Address pending octoDNS 2.x deprecations, require minimum of 1.5.x

--- a/octodns_digitalocean/__init__.py
+++ b/octodns_digitalocean/__init__.py
@@ -13,7 +13,7 @@ from octodns.provider.base import BaseProvider
 from octodns.record import Record
 
 # TODO: remove __VERSION__ with the next major version release
-__version__ = __VERSION__ = '1.0.0'
+__version__ = __VERSION__ = '1.0.1'
 
 
 class DigitalOceanClientException(ProviderException):


### PR DESCRIPTION
## 1.0.1 - 2026-04-03

Patch:
* Use new [changelet](https://github.com/octodns/changelet) tooling - [#44](https://github.com/octodns/octodns-digitalocean/pull/44)

